### PR TITLE
fix(auth): token exposed on login and register

### DIFF
--- a/src/Controllers/AuthController.cs
+++ b/src/Controllers/AuthController.cs
@@ -84,7 +84,8 @@ namespace TallerIDWM.Src.Controllers
                 var roleName = role.FirstOrDefault() ?? "User";
 
                 var token = _tokenService.GenerateToken(user, roleName);
-                var userDto = UserMapper.UserToAuthenticatedDto(user, token);
+                Response.Headers.Append("Authorization", $"Bearer {token}");
+                var userDto = UserMapper.UserToAuthenticatedDto(user);
 
                 return Ok(
                     new ApiResponse<AuthenticatedUserDto>(
@@ -161,7 +162,8 @@ namespace TallerIDWM.Src.Controllers
                 var roleName = roles.FirstOrDefault() ?? "User";
 
                 var token = _tokenService.GenerateToken(user, roleName);
-                var userDto = UserMapper.UserToAuthenticatedDto(user, token);
+                Response.Headers.Append("Authorization", $"Bearer {token}");
+                var userDto = UserMapper.UserToAuthenticatedDto(user);
 
                 return Ok(new ApiResponse<AuthenticatedUserDto>(true, "Login exitoso", userDto));
             }

--- a/src/Dtos/Auth/AuthenticatedUserDto.cs
+++ b/src/Dtos/Auth/AuthenticatedUserDto.cs
@@ -5,7 +5,5 @@ namespace TallerIDWM.Src.DTOs.Auth
         public string FirtsName { get; set; } = null!;
         public string LastName { get; set; } = null!;
         public string Email { get; set; } = null!;
-
-        public string Token { get; set; } = null!;
     }
 }

--- a/src/Mappers/UserMapper.cs
+++ b/src/Mappers/UserMapper.cs
@@ -44,13 +44,12 @@ namespace TallerIDWM.Src.Mappers
                 IsActive = user.IsActive,
             };
 
-        public static AuthenticatedUserDto UserToAuthenticatedDto(User user, string token) =>
+        public static AuthenticatedUserDto UserToAuthenticatedDto(User user) =>
             new()
             {
                 FirtsName = user.FirstName,
                 LastName = user.LastName,
                 Email = user.Email ?? string.Empty,
-                Token = token
             };
 
         public static void UpdateUserFromDto(User user, UpdateProfileDto dto)


### PR DESCRIPTION
se corrige la exposicion del token en la respuesta del login y register.
Dentro de postman se debe cambiar el script para guardar el token a:
const token = pm.response.headers.get('Authorization');
if (token) {
    pm.globals.set("token", token.replace("Bearer ", ""));
}